### PR TITLE
Solve Cumulative Layout Shift

### DIFF
--- a/app/views/layouts/_head.html.slim
+++ b/app/views/layouts/_head.html.slim
@@ -4,6 +4,7 @@ head
   title Todonaut
   = csrf_meta_tags
   = csp_meta_tag
+  = preload_link_tag 'Inter-roman.latin.var.woff2'
   = stylesheet_link_tag 'tailwind', 'inter-font', 'application', 'data-turbo-track': 'reload'
   = javascript_importmap_tags
   = javascript_include_tag 'direct_upload', 'data-turbo-track': 'reload'

--- a/app/views/layouts/_head.html.slim
+++ b/app/views/layouts/_head.html.slim
@@ -7,4 +7,4 @@ head
   = preload_link_tag 'Inter-roman.latin.var.woff2'
   = stylesheet_link_tag 'tailwind', 'inter-font', 'application', 'data-turbo-track': 'reload'
   = javascript_importmap_tags
-  = javascript_include_tag 'direct_upload', 'data-turbo-track': 'reload'
+  = javascript_include_tag 'direct_upload', 'data-turbo-track': 'reload', async: true


### PR DESCRIPTION
Fixes #54.

`Inter-roman.latin.var.woff2` is the primary font file. This is always used. Other inter font files are only used sometimes.

After:
<img width="969" alt="Screenshot 2023-03-10 at 13 55 24" src="https://user-images.githubusercontent.com/12763881/224309858-52a08977-faf8-4407-9001-8ec515c97dec.png">

[Preload, prefetch and other <link> tags](https://3perf.com/blog/link-rels/)

Additionally marks `direct_upload.js` `async`, as it is not necessary for rendering.