### PR TITLE
Lock better_errors gem to < 2.10

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -38,7 +38,7 @@ end
 
 group :development do
   gem 'awesome_print'
-  gem 'better_errors'
+  gem 'better_errors', '< 2.10' # 2.10 mistakenly requires sassc. Not going to add that.
   gem 'capistrano', require: false
   gem 'capistrano3-puma', require: false
   gem 'capistrano-asdf', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -78,10 +78,10 @@ GEM
     ast (2.4.2)
     awesome_print (1.9.2)
     bcrypt (3.1.18)
-    better_errors (2.10.0)
+    better_errors (2.9.1)
+      coderay (>= 1.0.0)
       erubi (>= 1.0.0)
       rack (>= 0.9.0)
-      rouge (>= 1.0.0)
     bootsnap (1.16.0)
       msgpack (~> 1.2)
     builder (3.2.4)
@@ -281,7 +281,6 @@ GEM
       rack (>= 1.4)
     retriable (3.1.2)
     rexml (3.2.5)
-    rouge (4.1.1)
     rspec-core (3.12.2)
       rspec-support (~> 3.12.0)
     rspec-expectations (3.12.3)
@@ -398,7 +397,7 @@ DEPENDENCIES
   ar_lazy_preload
   awesome_print
   bcrypt
-  better_errors
+  better_errors (< 2.10)
   bootsnap
   capistrano
   capistrano-asdf


### PR DESCRIPTION
See https://github.com/BetterErrors/better_errors/issues/516.