### PR TITLE
Delete github git_source from Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 source 'https://rubygems.org'
-git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
 ruby '3.1.2'
 


### PR DESCRIPTION
`git_source(:github)` was necessary with Bundler 1 for security: https://bundler.io/guides/git.html#security.
With Bundler 2 this is no longer needed: https://bundler.io/guides/bundler_2_upgrade.html.