### PR TITLE
Fix Webdrivers missing version error

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -32,7 +32,7 @@ group :development, :test do
   gem 'rubocop-performance', require: false
   gem 'rubocop-rails', require: false
   gem 'rubocop-rspec', require: false
-  gem 'webdrivers'
+  gem 'selenium-webdriver'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -332,7 +332,7 @@ GEM
     ruby-progressbar (1.13.0)
     ruby2_keywords (0.0.5)
     rubyzip (2.3.2)
-    selenium-webdriver (4.10.0)
+    selenium-webdriver (4.11.0)
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 3.0)
       websocket (~> 1.0)
@@ -381,10 +381,6 @@ GEM
       concurrent-ruby (~> 1.0)
     uber (0.1.0)
     unicode-display_width (2.4.2)
-    webdrivers (5.2.0)
-      nokogiri (~> 1.6)
-      rubyzip (>= 1.3.0)
-      selenium-webdriver (~> 4.0)
     webrick (1.8.1)
     websocket (1.2.9)
     websocket-driver (0.7.5)
@@ -429,13 +425,13 @@ DEPENDENCIES
   rubocop-performance
   rubocop-rails
   rubocop-rspec
+  selenium-webdriver
   sentry-rails
   slim-rails
   sprockets-rails
   stackprof
   tailwindcss-rails
   turbo-rails
-  webdrivers
 
 RUBY VERSION
    ruby 3.1.2p20


### PR DESCRIPTION
Fixes this error when running feature specs:
```
Webdrivers::VersionError:
  Unable to find latest point release version for 115.0.5790. You appear to be using a non-production version of Chrome. Please set `Webdrivers::Chromedriver.required_version = <desired driver version>` to a known chromedriver version: https://chromedriver.storage.googleapis.com/index.html
```

From https://ruby.social/@ajaya/110806302052230819:
> Now that Chrome 15 is out, folks using webdriver gem, will start getting errors like 'Unable to find latest point release version for 115.0.5790'. To solve this, follow along.
- Remove wedriver gem(https://github.com/titusfortner/webdrivers/issues/247#issuecomment-1641139415) 
- Upgrade selenium-webdriver, capybara gems

Also see https://github.com/rails/rails/pull/48847.