### PR TITLE
Remove tailwind plugin which is included by default anyway

### DIFF
--- a/config/tailwind.config.js
+++ b/config/tailwind.config.js
@@ -26,7 +26,6 @@ module.exports = {
     require('@tailwindcss/forms'),
     require('@tailwindcss/aspect-ratio'),
     require('@tailwindcss/typography'),
-    require('@tailwindcss/line-clamp'),
     require('@tailwindcss/container-queries'),
   ]
 }


### PR DESCRIPTION
Fixes this error when precmpiling assets:
```
      warn - As of Tailwind CSS v3.3, the `@tailwindcss/line-clamp` plugin is now included by default.
      warn - Remove it from the `plugins` array in your configuration to eliminate this warning.
```