### PR TITLE
Unlock better_errors gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -41,7 +41,7 @@ end
 
 group :development do
   gem 'awesome_print'
-  gem 'better_errors', '< 2.10' # 2.10 mistakenly requires sassc. Not going to add that.
+  gem 'better_errors'
   gem 'capistrano', require: false
   gem 'capistrano3-puma', require: false
   gem 'capistrano-asdf', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -89,10 +89,10 @@ GEM
     base64 (0.2.0)
     bcrypt (3.1.20)
     bcrypt_pbkdf (1.1.0)
-    better_errors (2.9.1)
-      coderay (>= 1.0.0)
+    better_errors (2.10.1)
       erubi (>= 1.0.0)
       rack (>= 0.9.0)
+      rouge (>= 1.0.0)
     bigdecimal (3.1.8)
     bootsnap (1.18.3)
       msgpack (~> 1.2)
@@ -337,6 +337,7 @@ GEM
     retriable (3.1.2)
     rexml (3.2.8)
       strscan (>= 3.0.9)
+    rouge (4.2.1)
     rspec-core (3.13.0)
       rspec-support (~> 3.13.0)
     rspec-expectations (3.13.0)
@@ -466,7 +467,7 @@ DEPENDENCIES
   ar_lazy_preload
   awesome_print
   bcrypt
-  better_errors (< 2.10)
+  better_errors
   bootsnap
   capistrano
   capistrano-asdf


### PR DESCRIPTION
The issue has been fixed: https://github.com/BetterErrors/better_errors/issues/516.
PR that locked the version: #62.